### PR TITLE
feat(nested keys): add ability to pass in keypath for object value

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -18,6 +18,15 @@
         "infra",
         "test"
       ]
+    },
+    {
+      "login": "conorhastings",
+      "name": "Conor Hastings",
+      "avatar_url": "https://avatars.githubusercontent.com/u/8263298?v=3",
+      "profile": "http://conorhastings.com",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Simple, expected, and deterministic best-match sorting of an array in JavaScript
 [![downloads][downloads-badge]][npm-stat]
 [![MIT License][license-badge]][LICENSE]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Donate][donate-badge]][donate]
 [![Code of Conduct][coc-badge]][coc]
@@ -109,8 +109,8 @@ You might try [Fuse.js](https://github.com/krisk/Fuse). It uses advanced math fa
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/match-sorter/commits?author=kentcdodds) [📖](https://github.com/kentcdodds/match-sorter/commits?author=kentcdodds) 🚇 [⚠️](https://github.com/kentcdodds/match-sorter/commits?author=kentcdodds) |
-| :---: |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/match-sorter/commits?author=kentcdodds) [📖](https://github.com/kentcdodds/match-sorter/commits?author=kentcdodds) 🚇 [⚠️](https://github.com/kentcdodds/match-sorter/commits?author=kentcdodds) | [<img src="https://avatars.githubusercontent.com/u/8263298?v=3" width="100px;"/><br /><sub>Conor Hastings</sub>](http://conorhastings.com)<br />[💻](https://github.com/kentcdodds/match-sorter/commits?author=conorhastings) |
+| :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification. Contributions of any kind welcome!

--- a/other/ROADMAP.md
+++ b/other/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Want to do
 
-- Support nested `keys` like `name.first`
+- ideas?
 
 ## Might do
 

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,8 @@ function getHighestRanking(item, keys, value) {
     return {rank: getMatchRanking(item, value), keyIndex: -1}
   }
   return keys.reduce(({rank, keyIndex}, key, i) => {
-    const newRank = getMatchRanking(item[key], value)
+    const itemValue = getItemValue(item, key)
+    const newRank = getMatchRanking(itemValue, value)
     if (newRank > rank) {
       rank = newRank
       keyIndex = i
@@ -169,6 +170,20 @@ function sortRankedItems(a, b) {
   } else {
     return aRank > bRank ? aFirst : bFirst
   }
+}
+
+/**
+ * Gets value for key in item at arbitrarily nested keypath
+ * @param {Object} item - the item
+ * @param {Object} key - the potentially nested keypath
+ * @return {String} - the value at nested keypath
+ */
+function getItemValue(item, key) {
+  const isNested = key.indexOf('.') !== -1
+  if (!isNested) {
+    return item[key]
+  }
+  return key.split('.').reduce((itemObj, nestedKey) => itemObj[nestedKey], item)
 }
 
 module.exports = exports.default // CommonJS compat

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -115,6 +115,21 @@ const tests = {
       {first: 'not', second: 'not', third: 'not', fourth: 'match'},
     ],
   },
+  'can handle objected with nested keys': {
+    input: [
+      [
+        {name: {first: 'baz'}},
+        {name: {first: 'bat'}},
+        {name: {first: 'foo'}},
+      ],
+      'ba',
+      {keys: ['name.first']},
+    ],
+    output: [
+      {name: {first: 'baz'}},
+      {name: {first: 'bat'}},
+    ],
+  },
   'when providing a rank threshold of NO_MATCH, it returns all of the items': {
     input: [
       ['orange', 'apple', 'grape', 'banana'],


### PR DESCRIPTION
This allows you to pass in keypaths instead of just single keys.
Makes things such as {keys: ['name.first']} possible.

closes #1