### PR TITLE
feat(match): ignore diacritics when matching by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ matchSorter(otherThings, 'app', {threshold: matchSorter.rankings.WORD_STARTS_WIT
  * - MATCHES
  * - NO_MATCH
  */
+
+// **keepDiacritics** (defaults to false)
+// by default, match-sorter will strip diacritics before doing any comparisons.
+// this is the default because it makes the most sense from a UX perspective.
+// You can disable this behavior by specifying keepDiacritics: false
+const thingsWithDiacritics = ['jalapeño', 'à la carte', 'café', 'papier-mâché', 'à la mode']
+matchSorter(thingsWithDiacritics, 'aa') // ['jalapeño', 'à la carte', 'papier-mâché', 'à la mode']
+matchSorter(thingsWithDiacritics, 'aa', {keepDiacritics: true}) // ['jalapeño', 'à la carte']
+matchSorter(thingsWithDiacritics, 'à', {keepDiacritics: true}) // ['à la carte', 'à la mode']
 ```
 
 > In the examples above, we're using CommonJS. If you're using ES6 modules, then you can do:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,12 @@
   "keywords": [],
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
-  "dependencies": {},
+  "bundledDependencies": [
+    "diacritic"
+  ],
+  "dependencies": {
+    "diacritic": "0.0.2"
+  },
   "devDependencies": {
     "all-contributors-cli": "^3.0.0",
     "ava": "^0.16.0",

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -189,6 +189,25 @@ const tests = {
       'app', 'apple', 'apply', 'fiji apple',
     ],
   },
+  'defaults to ignore diacritics': {
+    input: [
+      ['jalapeño', 'à la carte', 'café', 'papier-mâché', 'à la mode'],
+      'aa',
+    ],
+    output: [
+      'jalapeño', 'à la carte', 'papier-mâché', 'à la mode',
+    ],
+  },
+  'takes diacritics in account when keepDiacritics specified as true': {
+    input: [
+      ['jalapeño', 'à la carte', 'papier-mâché', 'à la mode'],
+      'aa',
+      {keepDiacritics: true},
+    ],
+    output: [
+      'jalapeño', 'à la carte',
+    ],
+  },
 }
 
 Object.keys(tests).forEach(title => {


### PR DESCRIPTION
It's reasonable to consider this change breaking, but I think that it's unlikely that anyone is depending on what I would consider a bug.

This adds our first dependency. Everything seems to be working with bundledDependencies (tested locally) and the UMD builds.

This should be merged after #9 is merged. I think I may need to rebase this branch when #9 is merged because we're doing squash-and-merge. We'll see what happens.

Closes #8