### PR TITLE
skip search/sort when search term is empty

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -344,6 +344,22 @@ const tests = {
       'superduperfile',
     ],
   },
+  'skip matching when no search value is absent': {
+    input: [
+      [
+        {tea: 'Milk', alias: 'moo'},
+        {tea: 'Oolong', alias: 'B'},
+        {tea: 'Green', alias: 'C'},
+      ],
+      '',
+      {keys: ['tea']},
+    ],
+    output: [
+      {tea: 'Milk', alias: 'moo'},
+      {tea: 'Oolong', alias: 'B'},
+      {tea: 'Green', alias: 'C'},
+    ],
+  },
 }
 
 Object.keys(tests).forEach(title => {

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,9 @@ matchSorter.caseRankings = caseRankings
  * @return {Array} - the new sorted array
  */
 function matchSorter(items, value, options = {}) {
+  // not performing any search/sort if value(search term) is empty
+  if (!value) return items
+
   const {keys, threshold = rankings.MATCHES} = options
   const matchedItems = items.reduce(reduceItemsToRanked, [])
   return matchedItems.sort(sortRankedItems).map(({item}) => item)
@@ -91,7 +94,7 @@ function getHighestRanking(item, keys, value, options) {
  * @returns {Number} the ranking for how well stringToRank matches testString
  */
 function getMatchRanking(testString, stringToRank, options) {
-  /* eslint complexity:[2, 11] */
+  /* eslint complexity:[2, 12] */
   testString = prepareValueForComparison(testString, options)
   stringToRank = prepareValueForComparison(stringToRank, options)
 
@@ -109,7 +112,7 @@ function getMatchRanking(testString, stringToRank, options) {
   const isPartial = isPartialOfCase(testString, stringToRank, caseRank)
   const isCasedAcronym = isCaseAcronym(testString, stringToRank, caseRank)
 
-  // Lowercasing before further comparison
+  // Lower casing before further comparison
   testString = testString.toLowerCase()
   stringToRank = stringToRank.toLowerCase()
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
when the search term is empty, then skipping all operations and returning the original input

<!-- Why are these changes necessary? -->
**Why**:
since the matchSorter perform `sort`, it changes the input even when nothing is searched. This skip step now prevents that from happening.

<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
