### PR TITLE
Replaced String.includes() with indexOf() due to IE incompatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -187,8 +187,8 @@ function getAcronym(string) {
  */
 function getCaseRanking(testString) {
   const containsUpperCase = testString.toLowerCase() !== testString
-  const containsDash = testString.includes('-')
-  const containsUnderscore = testString.includes('_')
+  const containsDash = testString.indexOf('-') >= 0
+  const containsUnderscore = testString.indexOf('_') >= 0
 
   if (!containsUpperCase && !containsUnderscore && containsDash) {
     return caseRankings.KEBAB


### PR DESCRIPTION
Closes #44 

**What**:
Replaced a use of `String.prototype.includes` with `String.prototype.indexOf`. 

**Why**:
The method mentioned above is not supported by Internet Explorer, causing the lib to err when the user hasn't added a polyfill on the application side.

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#Browser_compatibility

<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests - tests are passing, no need to add/change tests.
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
