### PR TITLE
Sort same ranked items alphabetically

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -44,25 +44,21 @@ const tests = {
       'ttotc', // case-sensitive-equal
       'tTOtc', // equal
       'TTotc', // equal2
-      'ttotc-starts with', // startsWith
-      'ttotc-2nd-starts with', // startsWith2
-      'Word starts with ttotc-first right?', // wordStartsWith
-      'Another word starts with ttotc-second, super!', // wordStartsWith2
+      'ttotc-2nd-starts with', // startsWith
+      'ttotc-starts with', // startsWith2
+      'Another word starts with ttotc-second, super!', // wordStartsWith
+      'Word starts with ttotc-first right?', // wordStartsWith2
       'PascalTtotcCase', // case string
       'kebab-ttotc-case', // case string
       'TheTailOfTwoCities', // case acronym
       'the_tail_of_two_cities', // case acronym2
       'The 1-ttotc-2 container', // contains
       'The second 3-ttotc-4 container', // contains2
-      'The Tail of Two Cities 1', // acronym
-      'The Tail of Two Cities', // acronym2
-      'The Tail of Forty Cities', // match
-      'The Tail of Fifty Cities', // match2
+      'The Tail of Two Cities', // acronym
+      'The Tail of Two Cities 1', // acronym2
+      'The Tail of Fifty Cities', // match
+      'The Tail of Forty Cities', // match2
     ],
-  },
-  'sorts equally ranking items in the same order in which they appeared in the original array': {
-    input: [['Foo1', 'Bar', 'Foo2'], 'foo'],
-    output: ['Foo1', 'Foo2'],
   },
   'no match for single character inputs that are not equal': {
     input: [['abc'], 'd'],
@@ -74,7 +70,7 @@ const tests = {
       'ba',
       {keys: ['name']},
     ],
-    output: [{name: 'baz'}, {name: 'bat'}],
+    output: [{name: 'bat'}, {name: 'baz'}],
   },
   'can handle multiple keys specified': {
     input: [
@@ -88,12 +84,12 @@ const tests = {
       {keys: ['name', 'reverse']},
     ],
     output: [
-      {name: 'baz', reverse: 'zab'},
-      {name: 'bat', reverse: 'tab'},
       {name: 'bag', reverse: 'gab'},
+      {name: 'bat', reverse: 'tab'},
+      {name: 'baz', reverse: 'zab'},
     ],
   },
-  'with multiple keys specified, all other things being equal, it prioritizes first keys first over index': {
+  'with multiple keys specified, all other things being equal, it prioritizes key index over alphabetizing': {
     input: [
       [
         {first: 'not', second: 'not', third: 'match'},
@@ -137,7 +133,7 @@ const tests = {
       'ba',
       {keys: ['name.first']},
     ],
-    output: [{name: {first: 'baz'}}, {name: {first: 'bat'}}],
+    output: [{name: {first: 'bat'}}, {name: {first: 'baz'}}],
   },
   'can handle property callback': {
     input: [
@@ -145,7 +141,7 @@ const tests = {
       'ba',
       {keys: [item => item.name.first]},
     ],
-    output: [{name: {first: 'baz'}}, {name: {first: 'bat'}}],
+    output: [{name: {first: 'bat'}}, {name: {first: 'baz'}}],
   },
   'can handle keys that are an array of values': {
     input: [
@@ -197,7 +193,7 @@ const tests = {
     // Green is missing due to no match
     output: [{tea: 'Milk', alias: 'moo'}, {tea: 'Oolong', alias: 'B'}],
   },
-  'when using arrays of values, when things are equal, the one with the higher index wins': {
+  'when using arrays of values, when things are equal, the one with the higher key index wins': {
     input: [
       [
         {favoriteIceCream: ['mint', 'chocolate']},
@@ -217,7 +213,7 @@ const tests = {
       'ap',
       {threshold: rankings.NO_MATCH},
     ],
-    output: ['apple', 'grape', 'orange', 'banana'],
+    output: ['apple', 'grape', 'banana', 'orange'],
   },
   'when providing a rank threshold of EQUAL, it returns only the items that are equal': {
     input: [
@@ -336,14 +332,14 @@ const tests = {
     ],
     output: [
       'snake_case_contained_in_the_word',
-      'startingWith_s',
       'somethingcontainedintheword',
+      'startingWith_s',
       'camelCaseContainedInTheWord',
       'PascalCaseContainedInTheWord',
       'kebab-case-contained-in-the-word',
-      'fakeCase_one',
       'fake_case-two',
       'fake_caseThree',
+      'fakeCase_one',
     ],
   },
   'takes case and acronym into account': {
@@ -405,6 +401,32 @@ const tests = {
   'case insensitive cyrillic match': {
     input: [['Привет', 'Лед'], 'л'],
     output: ['Лед'],
+  },
+  'should sort same ranked items alphabetically while when mixed with diacritics': {
+    input: [
+      [
+        'jalapeño',
+        'anothernodiacritics',
+        'à la carte',
+        'nodiacritics',
+        'café',
+        'papier-mâché',
+        'à la mode',
+      ],
+      'z',
+      {
+        threshold: rankings.NO_MATCH,
+      },
+    ],
+    output: [
+      'à la carte',
+      'à la mode',
+      'anothernodiacritics',
+      'café',
+      'jalapeño',
+      'nodiacritics',
+      'papier-mâché',
+    ],
   },
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -46,14 +46,14 @@ function matchSorter(items, value, options = {}) {
   return matchedItems.sort(sortRankedItems).map(({item}) => item)
 
   function reduceItemsToRanked(matches, item, index) {
-    const {rank, keyIndex, keyThreshold = threshold} = getHighestRanking(
-      item,
-      keys,
-      value,
-      options,
-    )
+    const {
+      rankedItem,
+      rank,
+      keyIndex,
+      keyThreshold = threshold,
+    } = getHighestRanking(item, keys, value, options)
     if (rank >= keyThreshold) {
-      matches.push({item, rank, index, keyIndex})
+      matches.push({rankedItem, item, rank, index, keyIndex})
     }
     return matches
   }
@@ -70,6 +70,8 @@ function matchSorter(items, value, options = {}) {
 function getHighestRanking(item, keys, value, options) {
   if (!keys) {
     return {
+      // ends up being duplicate of 'item' in matches but consistent
+      rankedItem: item,
       rank: getMatchRanking(item, value, options),
       keyIndex: -1,
       keyThreshold: options.threshold,
@@ -90,7 +92,7 @@ function getHighestRanking(item, keys, value, options) {
         keyIndex = i
         keyThreshold = threshold
       }
-      return {rank, keyIndex, keyThreshold}
+      return {rankedItem: itemValue, rank, keyIndex, keyThreshold}
     },
     {rank: rankings.NO_MATCH, keyIndex: -1, keyThreshold: options.threshold},
   )
@@ -300,7 +302,7 @@ function isCaseAcronym(testString, stringToRank, caseRank) {
  * rankings.MATCHES + 1 for how well stringToRank matches testString
  */
 function getClosenessRanking(testString, stringToRank) {
-  let matchingInOrderCharCount = 0;
+  let matchingInOrderCharCount = 0
   let charNumber = 0
   function findMatchingCharacter(matchChar, string, index) {
     for (let j = index; j < string.length; j++) {
@@ -313,10 +315,10 @@ function getClosenessRanking(testString, stringToRank) {
     return -1
   }
   function getRanking(spread) {
-    const spreadPercentage = 1 / spread;
-    const inOrderPercentage = matchingInOrderCharCount / stringToRank.length;
-    const ranking  = 1 + inOrderPercentage * spreadPercentage;
-    return ranking;
+    const spreadPercentage = 1 / spread
+    const inOrderPercentage = matchingInOrderCharCount / stringToRank.length
+    const ranking = rankings.MATCHES + inOrderPercentage * spreadPercentage
+    return ranking
   }
   const firstIndex = findMatchingCharacter(stringToRank[0], testString, 0)
   if (firstIndex < 0) {
@@ -346,12 +348,12 @@ function getClosenessRanking(testString, stringToRank) {
 function sortRankedItems(a, b) {
   const aFirst = -1
   const bFirst = 1
-  const {rank: aRank, index: aIndex, keyIndex: aKeyIndex} = a
-  const {rank: bRank, index: bIndex, keyIndex: bKeyIndex} = b
+  const {rankedItem: aRankedItem, rank: aRank, keyIndex: aKeyIndex} = a
+  const {rankedItem: bRankedItem, rank: bRank, keyIndex: bKeyIndex} = b
   const same = aRank === bRank
   if (same) {
     if (aKeyIndex === bKeyIndex) {
-      return aIndex < bIndex ? aFirst : bFirst
+      return aRankedItem.localeCompare(bRankedItem)
     } else {
       return aKeyIndex < bKeyIndex ? aFirst : bFirst
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

1. Sort same ranked items alphabetically rather than by the index they were inputted.
2. Updated tests.
3. One new test.

<!-- Why are these changes necessary? -->

**Why**:

Currently, if items are the same rank with the same key based index, the items are sorted based on their index in the starting input. This is fine in general but I believe it makes more sense to sort them alphabetically when they have the same ranking and also by length allowing the smaller words to float to the top and make filtering a progressive act.

Example:

search: `'ap'`
input: `['wrapped','snap', 'pap']`
old output: `['wrapped','snap', 'pap']`
new output: `['pap', 'snap', 'wrapped']`

<!-- How were these changes implemented? -->

**How**:

We can take advantage of the base [String.prototype.localeCompare()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare) to do a comparison while still accepting diacritics.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->


**Comments**

This may need discussion and you may not like the approach or the idea at all, just let me know or if you find any issues.  

Thanks!