### PR TITLE
fix: rankedItem casting to string (#64)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -353,7 +353,7 @@ function sortRankedItems(a, b) {
   const same = aRank === bRank
   if (same) {
     if (aKeyIndex === bKeyIndex) {
-      return aRankedItem.localeCompare(bRankedItem)
+      return String(aRankedItem).localeCompare(bRankedItem)
     } else {
       return aKeyIndex < bKeyIndex ? aFirst : bFirst
     }


### PR DESCRIPTION
Bug fix. For more information: [#64](https://github.com/kentcdodds/match-sorter/issues/65)