### PR TITLE
Allow collections to maintain their sort order

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This ranking seems to make sense in people's minds. At least it does in mine. Fe
   - [keys: `[string]`](#keys-string)
   - [threshold: `number`](#threshold-number)
   - [keepDiacritics: `boolean`](#keepdiacritics-boolean)
+  - [preserveSort: `boolean`](#preservesort-boolean)
 - [Using ES6?](#using-es6)
 - [Inspiration](#inspiration)
 - [Other Solutions](#other-solutions)
@@ -253,6 +254,19 @@ matchSorter(thingsWithDiacritics, 'aa', {keepDiacritics: true})
 
 matchSorter(thingsWithDiacritics, 'à', {keepDiacritics: true})
 // ['à la carte', 'à la mode']
+```
+
+### preserveSort: `boolean`
+
+_Default: `false`_
+
+By default, match-sorter will return a collection sorted by its rank.
+
+You can disble this behavior by specifying `preserveSort: true`
+
+```javascript
+const list = ['hey', 'hello', 'sup', 'yo', 'hi]
+matchSorter(list, 'h', {preserveSort: true}) // ['hey', 'hello', 'hi']
 ```
 
 ## Using ES6?

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -425,6 +425,10 @@ const tests = {
       'papier-mâché',
     ],
   },
+  'should preserve the sort of the input array when indicated': {
+    input: [['Charzard', 'Chakotay', 'Brunt'], 'Ch', {preserveSort: true}],
+    output: ['Charzard', 'Chakotay'],
+  },
 }
 
 Object.keys(tests).forEach(title => {

--- a/src/index.js
+++ b/src/index.js
@@ -41,8 +41,11 @@ function matchSorter(items, value, options = {}) {
   // not performing any search/sort if value(search term) is empty
   if (!value) return items
 
-  const {keys, threshold = rankings.MATCHES} = options
+  const {keys, threshold = rankings.MATCHES, preserveSort} = options
   const matchedItems = items.reduce(reduceItemsToRanked, [])
+  if (preserveSort) {
+    return matchedItems.map(({item}) => item)
+  }
   return matchedItems.sort(sortRankedItems).map(({item}) => item)
 
   function reduceItemsToRanked(matches, item, index) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Adds an option to allow users to maintain their original sort order (while still filtering down their result set)

<!-- Why are these changes necessary? -->

**Why**:
I'm encountering a use case in our company's application where:
1. We need a to be able to quickly filter down a list of options client-side via a text-based search
1. We need to maintain the original order of those options as delivered from our server

Here's a _rough_ mockup of the UI we're working on:
![2019-09-19 17 19 03](https://user-images.githubusercontent.com/675732/65285312-b0d96c00-db01-11e9-9b7b-dc7c0cc1c0db.gif)

For some context on our use-case:

Our company is building out a marketplace for landscape contractors to acquire plant material, and the "sizes" you're seeing there are a combination of some sort of dimensional measurement and the container of said plant being sold. Landscape contractors are used to seeing these different sizes grouped and sorted in a very particular way (as they were coming from using print catalogs with large tables before using our app), and we are currently maintaining said sort order within the application code of our server.

Counterintuitive as it might be, we only need the `match` aspect of `match-sorter`, as we'd like to maintain that arrangement & grouping that comes back from our server as to not jar any customers using this filter while still letting folks filter down a large list of results. 

Here's what that same UI looks like when sorted by the rank returned by `matchSorter`:

![2019-09-19 17 27 03](https://user-images.githubusercontent.com/675732/65285680-ce5b0580-db02-11e9-8350-a152b95d9cd2.gif)

As you can see, one of the Container options (`18" 18"w #2 Container`) jumps below `BB`, even though it comes before all the BB options in the list. Here's how we'd prefer that behavior to look to an end user:

![2019-09-19 17 36 29](https://user-images.githubusercontent.com/675732/65286129-14649900-db04-11e9-872f-f0c57df95163.gif)

<!-- How were these changes implemented? -->

**How**:
I added an option to the main `matchSorter` method to allow users to preserve their initial sort order. All this does is skip the step where the reduced input gets sorted by rank.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
Let me know if this behavior is out-of-scope for this library! We have a workaround, but since the change was relatively straightforward I figured we might as well explore contributing something back upstream.

Our workaround:

```jsx
const sizes = [/* ... */]

function Component({sizes}) {
  const [query, setQuery] = useState("");
  // Omitting all the code for the input actually changing `query`

  const filteredSizes = matchSorter(sizes, query)

  return <ul>
    {sizes
      .filter(size => filteredSizes.includes(size))
      .map(size => <li key={size}>{size}</li>)}
  </ul>
}
```