### PR TITLE
Add CodeFund sponsorship message to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 <div align="center">
+<a href="https://codefund.io/properties/446/visit-sponsor">
+  <img src="https://codefund.io/properties/446/sponsor" />
+</a>
+</div>
+  
+<div align="center">
 <h1>match-sorter</h1>
 
 <p>Simple, expected, and deterministic best-match sorting of an array in JavaScript</p>


### PR DESCRIPTION
[CodeFund](https://codefund.io) provides ethical sponsorships to open source maintainers. This PR will place the "Sponsored by" image at the top of the README. The sponsoring companies are not paying per click nor impression. They are paying the maintainer(s) on a per-month basis to be the primary sponsor of this project.

Here's a preview of what the image will look like:

![image](https://user-images.githubusercontent.com/12481/65704556-fd620180-e043-11e9-852d-7077c65558e0.png)

