### PR TITLE
fix: sort objects by matched key only (fixes #78)

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -425,6 +425,22 @@ const tests = {
       'papier-mâché',
     ],
   },
+  'returns objects in their original order': {
+    input: [
+      [
+        {country: 'Italy', counter: 3},
+        {country: 'Italy', counter: 2},
+        {country: 'Italy', counter: 1},
+      ],
+      'Italy',
+      {keys: ['country', 'counter']},
+    ],
+    output: [
+      {country: 'Italy', counter: 3},
+      {country: 'Italy', counter: 2},
+      {country: 'Italy', counter: 1},
+    ],
+  },
 }
 
 Object.keys(tests).forEach(title => {

--- a/src/index.js
+++ b/src/index.js
@@ -79,8 +79,13 @@ function getHighestRanking(item, keys, value, options) {
   }
   const valuesToRank = getAllValuesToRank(item, keys)
   return valuesToRank.reduce(
-    ({rank, keyIndex, keyThreshold}, {itemValue, attributes}, i) => {
+    (
+      {rank, rankedItem, keyIndex, keyThreshold},
+      {itemValue, attributes},
+      i,
+    ) => {
       let newRank = getMatchRanking(itemValue, value, options)
+      let newRankedItem = rankedItem
       const {minRanking, maxRanking, threshold} = attributes
       if (newRank < minRanking && newRank >= rankings.MATCHES) {
         newRank = minRanking
@@ -91,8 +96,9 @@ function getHighestRanking(item, keys, value, options) {
         rank = newRank
         keyIndex = i
         keyThreshold = threshold
+        newRankedItem = itemValue
       }
-      return {rankedItem: itemValue, rank, keyIndex, keyThreshold}
+      return {rankedItem: newRankedItem, rank, keyIndex, keyThreshold}
     },
     {rank: rankings.NO_MATCH, keyIndex: -1, keyThreshold: options.threshold},
   )
@@ -342,8 +348,7 @@ function getClosenessRanking(testString, stringToRank) {
  * Sorts items that have a rank, index, and keyIndex
  * @param {Object} a - the first item to sort
  * @param {Object} b - the second item to sort
- * @return {Number} -1 if a should come first, 1 if b should come first
- * Note: will never return 0
+ * @return {Number} -1 if a should come first, 1 if b should come first, 0 if equal
  */
 function sortRankedItems(a, b) {
   const aFirst = -1
@@ -353,6 +358,9 @@ function sortRankedItems(a, b) {
   const same = aRank === bRank
   if (same) {
     if (aKeyIndex === bKeyIndex) {
+      // localeCompare returns 0 if both values are equal,
+      // so we rely on JS engines stably sorting the results
+      // (de facto, all modern engine do this).
       return String(aRankedItem).localeCompare(bRankedItem)
     } else {
       return aKeyIndex < bKeyIndex ? aFirst : bFirst


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->
When using multiple keys to filter objects, the objects are always sorted by the last key in the list (if the ranks are otherwise equal), no matter which key actually matched. This PR fixes that behavior.

**Why**:

Sorting by last key is unexpected and most probably unintended py the original PR.
<!-- How were these changes implemented? -->

**How**:

I set the key to be sorted on to the one that actually matched.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->