### PR TITLE
fix: still sort when search value is absent

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -202,6 +202,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "RebeccaStevens",
+      "name": "Rebecca Stevens",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/7224206?v=4",
+      "profile": "https://github.com/RebeccaStevens",
+      "contributions": [
+        "bug"
+      ]
     }
   ]
 }

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -361,7 +361,7 @@ const tests = {
       'superduperfile',
     ],
   },
-  'skip matching when no search value is absent': {
+  'sort when search value is absent': {
     input: [
       [
         {tea: 'Milk', alias: 'moo'},
@@ -372,9 +372,9 @@ const tests = {
       {keys: ['tea']},
     ],
     output: [
+      {tea: 'Green', alias: 'C'},
       {tea: 'Milk', alias: 'moo'},
       {tea: 'Oolong', alias: 'B'},
-      {tea: 'Green', alias: 'C'},
     ],
   },
   'only match when key meets threshold': {

--- a/src/index.js
+++ b/src/index.js
@@ -41,9 +41,6 @@ const defaultBaseSortFn = (a, b) =>
  * @return {Array} - the new sorted array
  */
 function matchSorter(items, value, options = {}) {
-  // not performing any search/sort if value(search term) is empty
-  if (!value) return items
-
   const {
     keys,
     threshold = rankings.MATCHES,


### PR DESCRIPTION
fix #100

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Sort when search value is absent.

<!-- Why are these changes necessary? -->

**Why**: Consistency.

<!-- How were these changes implemented? -->

**How**: Don't early escape if search value is absent.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation "N/A"
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
