### PR TITLE
feat: handle nested arrays with wildcard keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,26 @@ const nestedObjList = [
 ]
 matchSorter(nestedObjList, 'j', {keys: ['name.0.first']})
 // [{name: {first: 'Janice'}}, {name: {first: 'Jen'}}]
+
 // matchSorter(nestedObjList, 'j', {keys: ['name[0].first']}) does not work
+```
+
+This even works with arrays of multiple nested objects: just specify the key
+using dot-notation like there is no array or, more explicitly, use the `*`
+wildcard instead of a numeric index.
+
+```javascript
+const nestedObjList = [
+  {aliases: [{name: {first: 'Janice'}},{name: {first: 'Jen'}}]},
+  {aliases: [{name: {first: 'Fred'}},{name: {first: 'Frederic'}}]},
+  {aliases: [{name: {first: 'George'}},{name: {first: 'Georgie'}}]},
+]
+matchSorter(nestedObjList, 'jen', {keys: ['aliases.name.first']})
+// [{aliases: [{name: {first: 'Janice'}},{name: {first: 'Jen'}}]}]
+matchSorter(nestedObjList, 'jen', {keys: ['aliases.*.name.first']})
+// [{aliases: [{name: {first: 'Janice'}},{name: {first: 'Jen'}}]}]
+matchSorter(nestedObjList, 'jen', {keys: ['aliases.0.name.first']})
+// []
 ```
 
 **Property Callbacks**: Alternatively, you may also pass in a callback function

--- a/README.md
+++ b/README.md
@@ -163,8 +163,7 @@ matchSorter(nestedObjList, 'j', {keys: ['name.0.first']})
 ```
 
 This even works with arrays of multiple nested objects: just specify the key
-using dot-notation like there is no array or, more explicitly, use the `*`
-wildcard instead of a numeric index.
+using dot-notation with the `*` wildcard instead of a numeric index.
 
 ```javascript
 const nestedObjList = [
@@ -172,8 +171,6 @@ const nestedObjList = [
   {aliases: [{name: {first: 'Fred'}},{name: {first: 'Frederic'}}]},
   {aliases: [{name: {first: 'George'}},{name: {first: 'Georgie'}}]},
 ]
-matchSorter(nestedObjList, 'jen', {keys: ['aliases.name.first']})
-// [{aliases: [{name: {first: 'Janice'}},{name: {first: 'Jen'}}]}]
 matchSorter(nestedObjList, 'jen', {keys: ['aliases.*.name.first']})
 // [{aliases: [{name: {first: 'Janice'}},{name: {first: 'Jen'}}]}]
 matchSorter(nestedObjList, 'jen', {keys: ['aliases.0.name.first']})

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -114,7 +114,7 @@ const tests: Record<string, TestCase> = {
     ],
     output: [{name: 'A', age: 0}],
   },
-  'can handle objected with nested keys': {
+  'can handle object with nested keys': {
     input: [
       [
         {name: {first: 'baz'}},
@@ -128,6 +128,51 @@ const tests: Record<string, TestCase> = {
       {keys: ['name.first']},
     ],
     output: [{name: {first: 'bat'}}, {name: {first: 'baz'}}],
+  },
+  'can handle object with an array of values with nested keys with a specific index': {
+    input: [
+      [
+        {aliases: [{name: {first: 'baz'}},{name: {first: 'foo'}},{name: null}]},
+        {aliases: [{name: {first: 'foo'}},{name: {first: 'bat'}},null]},
+        {aliases: [{name: {first: 'foo'}},{name: {first: 'foo'}}]},
+        {aliases: null},
+        {},
+        null,
+      ],
+      'ba',
+      {keys: ['aliases.0.name.first']},
+    ],
+    output: [{aliases: [{name: {first: 'baz'}},{name: {first: 'foo'}},{name: null}]}],
+  },
+  'can handle object with an array of values with nested keys with an explicit wildcard': {
+    input: [
+      [
+        {aliases: [{name: {first: 'baz'}},{name: {first: 'foo'}},{name: null}]},
+        {aliases: [{name: {first: 'foo'}},{name: {first: 'bat'}},null]},
+        {aliases: [{name: {first: 'foo'}},{name: {first: 'foo'}}]},
+        {aliases: null},
+        {},
+        null,
+      ],
+      'ba',
+      {keys: ['aliases.*.name.first']},
+    ],
+    output: [{aliases: [{name: {first: 'baz'}},{name: {first: 'foo'}},{name: null}]}, {aliases: [{name: {first: 'foo'}},{name: {first: 'bat'}},null]}],
+  },
+  'can handle object with an array of values with nested keys with an implicit wildcard': {
+    input: [
+      [
+        {aliases: [{name: {first: 'baz'}},{name: {first: 'foo'}},{name: null}]},
+        {aliases: [{name: {first: 'foo'}},{name: {first: 'bat'}},null]},
+        {aliases: [{name: {first: 'foo'}},{name: {first: 'foo'}}]},
+        {aliases: null},
+        {},
+        null,
+      ],
+      'ba',
+      {keys: ['aliases.name.first']},
+    ],
+    output: [{aliases: [{name: {first: 'baz'}},{name: {first: 'foo'}},{name: null}]}, {aliases: [{name: {first: 'foo'}},{name: {first: 'bat'}},null]}],
   },
   'can handle property callback': {
     input: [
@@ -147,6 +192,21 @@ const tests: Record<string, TestCase> = {
       ],
       'cc',
       {keys: ['favoriteIceCream']},
+    ],
+    output: [
+      {favoriteIceCream: ['candy cane', 'brownie']},
+      {favoriteIceCream: ['mint', 'chocolate']},
+    ],
+  },
+  'can handle keys that are an array of values with an explicit wildcard': {
+    input: [
+      [
+        {favoriteIceCream: ['mint', 'chocolate']},
+        {favoriteIceCream: ['candy cane', 'brownie']},
+        {favoriteIceCream: ['birthday cake', 'rocky road', 'strawberry']},
+      ],
+      'cc',
+      {keys: ['favoriteIceCream.*']},
     ],
     output: [
       {favoriteIceCream: ['candy cane', 'brownie']},

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -198,6 +198,21 @@ const tests: Record<string, TestCase> = {
       {favoriteIceCream: ['mint', 'chocolate']},
     ],
   },
+  'can handle nested keys that are an array of values': {
+    input: [
+      [
+        {favorite: {iceCream: ['mint', 'chocolate']}},
+        {favorite: {iceCream: ['candy cane', 'brownie']}},
+        {favorite: {iceCream: ['birthday cake', 'rocky road', 'strawberry']}},
+      ],
+      'cc',
+      {keys: ['favorite.iceCream']},
+    ],
+    output: [
+      {favorite: {iceCream: ['candy cane', 'brownie']}},
+      {favorite: {iceCream: ['mint', 'chocolate']}},
+    ],
+  },
   'can handle nested keys that are an array of values with a wildcard': {
     input: [
       [
@@ -211,6 +226,36 @@ const tests: Record<string, TestCase> = {
     output: [
       {favorite: {iceCream: ['candy cane', 'brownie']}},
       {favorite: {iceCream: ['mint', 'chocolate']}},
+    ],
+  },
+  'can handle nested keys that are an array of objects with a single wildcard': {
+    input: [
+      [
+        {favorite: {iceCream: [{tastes: ['vanilla', 'mint']}, {tastes: ['vanilla', 'chocolate']}]}},
+        {favorite: {iceCream: [{tastes: ['vanilla', 'candy cane']}, {tastes: ['vanilla', 'brownie']}]}},
+        {favorite: {iceCream: [{tastes: ['vanilla', 'birthday cake']}, {tastes: ['vanilla', 'rocky road']}, {tastes: ['strawberry']}]}},
+      ],
+      'cc',
+      {keys: ['favorite.iceCream.*.tastes']},
+    ],
+    output: [
+      {favorite: {iceCream: [{tastes:['vanilla', 'candy cane']}, {tastes:['vanilla', 'brownie']}]}},
+      {favorite: {iceCream: [{tastes:['vanilla', 'mint']}, {tastes:['vanilla', 'chocolate']}]}},
+    ],
+  },
+  'can handle nested keys that are an array of objects with two wildcards': {
+    input: [
+      [
+        {favorite: {iceCream: [{tastes: ['vanilla', 'mint']}, {tastes: ['vanilla', 'chocolate']}]}},
+        {favorite: {iceCream: [{tastes: ['vanilla', 'candy cane']}, {tastes: ['vanilla', 'brownie']}]}},
+        {favorite: {iceCream: [{tastes: ['vanilla', 'birthday cake']}, {tastes: ['vanilla', 'rocky road']}, {tastes: ['strawberry']}]}},
+      ],
+      'cc',
+      {keys: ['favorite.iceCream.*.tastes.*']},
+    ],
+    output: [
+      {favorite: {iceCream: [{tastes:['vanilla', 'candy cane']}, {tastes:['vanilla', 'brownie']}]}},
+      {favorite: {iceCream: [{tastes:['vanilla', 'mint']}, {tastes:['vanilla', 'chocolate']}]}},
     ],
   },
   'can handle keys with a maxRanking': {

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -144,7 +144,7 @@ const tests: Record<string, TestCase> = {
     ],
     output: [{aliases: [{name: {first: 'baz'}},{name: {first: 'foo'}},{name: null}]}],
   },
-  'can handle object with an array of values with nested keys with an explicit wildcard': {
+  'can handle object with an array of values with nested keys with a wildcard': {
     input: [
       [
         {aliases: [{name: {first: 'baz'}},{name: {first: 'foo'}},{name: null}]},
@@ -156,21 +156,6 @@ const tests: Record<string, TestCase> = {
       ],
       'ba',
       {keys: ['aliases.*.name.first']},
-    ],
-    output: [{aliases: [{name: {first: 'baz'}},{name: {first: 'foo'}},{name: null}]}, {aliases: [{name: {first: 'foo'}},{name: {first: 'bat'}},null]}],
-  },
-  'can handle object with an array of values with nested keys with an implicit wildcard': {
-    input: [
-      [
-        {aliases: [{name: {first: 'baz'}},{name: {first: 'foo'}},{name: null}]},
-        {aliases: [{name: {first: 'foo'}},{name: {first: 'bat'}},null]},
-        {aliases: [{name: {first: 'foo'}},{name: {first: 'foo'}}]},
-        {aliases: null},
-        {},
-        null,
-      ],
-      'ba',
-      {keys: ['aliases.name.first']},
     ],
     output: [{aliases: [{name: {first: 'baz'}},{name: {first: 'foo'}},{name: null}]}, {aliases: [{name: {first: 'foo'}},{name: {first: 'bat'}},null]}],
   },
@@ -198,7 +183,7 @@ const tests: Record<string, TestCase> = {
       {favoriteIceCream: ['mint', 'chocolate']},
     ],
   },
-  'can handle keys that are an array of values with an explicit wildcard': {
+  'can handle keys that are an array of values with a wildcard': {
     input: [
       [
         {favoriteIceCream: ['mint', 'chocolate']},
@@ -211,6 +196,21 @@ const tests: Record<string, TestCase> = {
     output: [
       {favoriteIceCream: ['candy cane', 'brownie']},
       {favoriteIceCream: ['mint', 'chocolate']},
+    ],
+  },
+  'can handle nested keys that are an array of values with a wildcard': {
+    input: [
+      [
+        {favorite: {iceCream: ['mint', 'chocolate']}},
+        {favorite: {iceCream: ['candy cane', 'brownie']}},
+        {favorite: {iceCream: ['birthday cake', 'rocky road', 'strawberry']}},
+      ],
+      'cc',
+      {keys: ['favorite.iceCream.*']},
+    ],
+    output: [
+      {favorite: {iceCream: ['candy cane', 'brownie']}},
+      {favorite: {iceCream: ['mint', 'chocolate']}},
     ],
   },
   'can handle keys with a maxRanking': {

--- a/src/index.ts
+++ b/src/index.ts
@@ -356,6 +356,11 @@ function getItemValues<ItemType>(
   let value: string | Array<string> | null
   if (typeof key === 'function') {
     value = key(item)
+  } else if (item == null) {
+    value = null
+  } else if (Object.hasOwnProperty.call(item, key)) {
+    // @ts-expect-error just like below...
+    value = item[key];
   } else {
     value = getNestedValue<ItemType>(key, item)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -360,6 +360,7 @@ function getItemValues<ItemType>(
     value = null
   } else if (Object.hasOwnProperty.call(item, key)) {
     // @ts-expect-error just like below...
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     value = item[key];
   } else {
     value = getNestedValue<ItemType>(key, item)
@@ -397,6 +398,7 @@ function getNestedValue<ItemType>(
 
     if (Object.hasOwnProperty.call(value,nestedKey)) {
       // @ts-expect-error lost on this one as well...
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const nestedValue = value[nestedKey]
       if (nestedValue != null) {
         return nestedValue
@@ -410,12 +412,13 @@ function getNestedValue<ItemType>(
         return value
       }
 
-      return value.reduce((values: Array<object | string>, arrayValue: object):
+      return value.reduce((values: Array<object | string>, arrayValue: object | null):
         | object
         | string
         | null => {
           if (arrayValue != null && Object.hasOwnProperty.call(arrayValue,nestedKey)) {
             // @ts-expect-error and here again...
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             const nestedArrayValue = arrayValue[nestedKey]
             if (nestedArrayValue != null) {
               values.push(nestedArrayValue)

--- a/src/index.ts
+++ b/src/index.ts
@@ -378,58 +378,38 @@ function getItemValues<ItemType>(
 
 /**
  * Given key: "foo.bar.baz"
- * And obj: {foo: {bar: {baz: 'buzz'}}}
+ * And item: {foo: {bar: {baz: 'buzz'}}}
  *   -> 'buzz'
  * @param key a dot-separated set of keys
- * @param obj the object to get the value from
+ * @param item the item to get the value from
  */
 function getNestedValue<ItemType>(
   key: string,
-  obj: ItemType,
+  item: ItemType,
 ): string | Array<string> | null {
   // @ts-expect-error really have no idea how to type this properly...
-  return key.split('.').reduce((value: object | null, nestedKey: string):
-    | object
-    | string
-    | null => {
-    if (value == null) {
-      return null
-    }
-
-    if (Object.hasOwnProperty.call(value,nestedKey)) {
-      // @ts-expect-error lost on this one as well...
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const nestedValue = value[nestedKey]
-      if (nestedValue != null) {
-        return nestedValue
+  return key.split('.').reduce((nestedItems: Array<object | string | null>, nestedKey: string): Array<object | string> => {
+    return nestedItems.reduce((values: Array<object | string>, nestedItem: Array<object | string> | object | string | null): Array<object | string> => {
+      if (nestedItem == null) {
+        return values
       }
-      return null
-    }
 
-    if (Array.isArray(value)) {
       if (nestedKey === "*") {
-        // ignore explicit wildcards
-        return value
+        return values.concat(nestedItem)
       }
 
-      return value.reduce((values: Array<object | string>, arrayValue: object | null):
-        | object
-        | string
-        | null => {
-          if (arrayValue != null && Object.hasOwnProperty.call(arrayValue,nestedKey)) {
-            // @ts-expect-error and here again...
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            const nestedArrayValue = arrayValue[nestedKey]
-            if (nestedArrayValue != null) {
-              values.push(nestedArrayValue)
-            }
-          }
-          return values
-        }, [])
-    }
+      if (Object.hasOwnProperty.call(nestedItem,nestedKey)) {
+        // @ts-expect-error and here again...
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const nestedValue = nestedItem[nestedKey]
+        if (nestedValue != null) {
+          values.push(nestedValue)
+        }
+      }
 
-    return null
-  }, obj)
+      return values
+    }, [])
+  }, [item])
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -260,7 +260,7 @@ function getClosenessRanking(testString: string, stringToRank: string): number {
     string: string,
     index: number,
   ) {
-    for (let j = index; j < string.length; j++) {
+    for (let j = index, J = string.length; j < J; j++) {
       const stringChar = string[j]
       if (stringChar === matchChar) {
         matchingInOrderCharCount += 1
@@ -280,7 +280,7 @@ function getClosenessRanking(testString: string, stringToRank: string): number {
     return rankings.NO_MATCH
   }
   charNumber = firstIndex
-  for (let i = 1; i < stringToRank.length; i++) {
+  for (let i = 1, I = stringToRank.length; i < I; i++) {
     const matchChar = stringToRank[i]
     charNumber = findMatchingCharacter(matchChar, testString, charNumber)
     const found = charNumber > -1

--- a/src/index.ts
+++ b/src/index.ts
@@ -435,17 +435,15 @@ function getAllValuesToRank<ItemType>(
   keys: Array<KeyOption<ItemType>>,
 ) {
   return keys.reduce<Array<{itemValue: string; attributes: KeyAttributes}>>(
-    (allVals, key) => {
-      const values = getItemValues(item, key)
-      if (values) {
-        values.forEach(itemValue => {
-          allVals.push({
-            itemValue,
-            attributes: getKeyAttributes(key),
-          })
+    (allValues, key) => {
+      const attributes = getKeyAttributes(key)
+      getItemValues(item, key).forEach(itemValue => {
+        allValues.push({
+          itemValue,
+          attributes,
         })
-      }
-      return allVals
+      })
+      return allValues
     },
     [],
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -388,12 +388,18 @@ function getNestedValues<ItemType>(
   path: string,
   item: ItemType,
 ): Array<string> {
+  const keys = path.split('.')
+
   type ValueA = Array<ItemType | IndexableByString | string>
   let values: ValueA = [item]
-  for (const nestedKey of path.split('.')) {
+
+  for (let i = 0, I = keys.length; i < I; i++) {
+    const nestedKey = keys[i]
     let nestedValues: ValueA = []
 
-    for (const nestedItem of values) {
+    for (let j = 0, J = values.length; j < J; j++) {
+      const nestedItem = values[j]
+
       if (nestedItem == null) continue
 
       if (Object.hasOwnProperty.call(nestedItem, nestedKey)) {
@@ -431,19 +437,19 @@ function getAllValuesToRank<ItemType>(
   item: ItemType,
   keys: Array<KeyOption<ItemType>>,
 ) {
-  return keys.reduce<Array<{itemValue: string; attributes: KeyAttributes}>>(
-    (allValues, key) => {
-      const attributes = getKeyAttributes(key)
-      for (const itemValue of getItemValues(item, key)) {
-        allValues.push({
-          itemValue,
-          attributes,
-        })
-      }
-      return allValues
-    },
-    [],
-  )
+  const allValues: Array<{itemValue: string, attributes: KeyAttributes}> = []
+  for (let j = 0, J = keys.length; j < J; j++) {
+    const key = keys[j]
+    const attributes = getKeyAttributes(key)
+    const itemValues = getItemValues(item, key)
+    for (let i = 0, I = itemValues.length; i < I; i++) {
+      allValues.push({
+        itemValue: itemValues[i],
+        attributes,
+      })
+    }
+  }
+  return allValues
 }
 
 const defaultKeyAttributes = {


### PR DESCRIPTION
**What**: Handle nested arrays with one or more wildcard keys. As an example

```javascript
const nestedObjList = [
  {aliases: [{name: {first: 'Janice'}},{name: {first: 'Jen'}}]},
  {aliases: [{name: {first: 'Fred'}},{name: {first: 'Frederic'}}]},
  {aliases: [{name: {first: 'George'}},{name: {first: 'Georgie'}}]},
]
matchSorter(nestedObjList, 'jen', {keys: ['aliases.*.name.first']})
// [{aliases: [{name: {first: 'Janice'}},{name: {first: 'Jen'}}]}]
matchSorter(nestedObjList, 'jen', {keys: ['aliases.name.first']})
// [{aliases: [{name: {first: 'Janice'}},{name: {first: 'Jen'}}]}]
matchSorter(nestedObjList, 'jen', {keys: ['aliases.0.name.first']})
// []
```

**Why**: Arrays like the above are relatively common in some applications that I'm working on. I really like the intuitive sorting of match-sorter so I'd love to be able to use this. However, using property callbacks for such a common case isn't ideal. So I thought I'd try making a pull request, hoping that this is something you might consider for merging.

**How**: The `.reduce` callback inside the `getNestedValue` function has gotten a lot more logic to possibly handle arrays. The calling `getItemValues` function now always returns an array, which simplifies the logic that returns the value a bit. Both the explicit `'aliases.*.name.first'` and implicit `'aliases.name.first'` wildcards are supported with this implementation; it was simpler to implement the latter while the former is clearer in use.

**Checklist**:

- [x] Documentation
- [x] Tests
- [ ] Ready to be merged

I sadly had some trouble running `npm run test:update`: it complains that not all branches are covered by the test cases. However, the lines that it says are uncovered are actually called, as far as I can tell, so I couldn't fix this..