### PR TITLE
Allow readonly arrays as inputs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ const defaultBaseSortFn: BaseSorter<unknown> = (a, b) =>
  * @return {Array} - the new sorted array
  */
 function matchSorter<ItemType = string>(
-  items: Array<ItemType>,
+  items: ReadonlyArray<ItemType>,
   value: string,
   options: MatchSorterOptions<ItemType> = {},
 ): Array<ItemType> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ type KeyOption<ItemType> =
   | string
 
 interface MatchSorterOptions<ItemType = unknown> {
-  keys?: Array<KeyOption<ItemType>>
+  keys?: ReadonlyArray<KeyOption<ItemType>>
   threshold?: Ranking
   baseSort?: BaseSorter<ItemType>
   keepDiacritics?: boolean
@@ -120,7 +120,7 @@ function matchSorter<ItemType = string>(
  */
 function getHighestRanking<ItemType>(
   item: ItemType,
-  keys: Array<KeyOption<ItemType>> | undefined,
+  keys: ReadonlyArray<KeyOption<ItemType>> | undefined,
   value: string,
   options: MatchSorterOptions<ItemType>,
 ): RankingInfo {
@@ -445,7 +445,7 @@ function getNestedValues<ItemType>(
  */
 function getAllValuesToRank<ItemType>(
   item: ItemType,
-  keys: Array<KeyOption<ItemType>>,
+  keys: ReadonlyArray<KeyOption<ItemType>>,
 ) {
   const allValues: Array<{itemValue: string; attributes: KeyAttributes}> = []
   for (let j = 0, J = keys.length; j < J; j++) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
The `items` parameter of `matchSorter` as well as the `keys` option are being changed to `ReadonlyArray` from a plain `Array`. This more closely represents the contract of the function, as it does not modify these arrays.
Fixes #128.

<!-- Why are these changes necessary? -->

**Why**:
Even though `matchSorter` does not modify its input array, it cannot be called with a value of type `ReadonlyArray`:
```typescript
const input: readonly string[] = ['foo', 'bar', 'baz'];
matchSorter(input, 'f'); // does not compile
```

<!-- How were these changes implemented? -->

**How**:
The required changes are simple: The input types are changed to `ReadyonlyArray`. This is not a breaking change, as `Array` is a subtype of `ReadonlyArray` in typescript, so "normal arrays" can be passed in like before.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A - The fact a new array is returned is already present in the documentation
- [ ] Tests N/A
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
