### PR TITLE
Removed obsolete threshold values

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,8 +275,6 @@ Available thresholds (from top to bottom) are:
 - EQUAL
 - STARTS_WITH
 - WORD_STARTS_WITH
-- STRING_CASE
-- STRING_CASE_ACRONYM
 - CONTAINS
 - ACRONYM
 - MATCHES _(default value)_


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Documentation for threshold was updated to remove parameters that don't exist anymore.

<!-- Why are these changes necessary? -->

**Why**: These parameters don't exist anymore and the docs for the threshold are a little confusing.

<!-- How were these changes implemented? -->

**How**: Parameters removed from documentation.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ X ] Documentation
- [ ] Tests N/A
- [ X ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I was reading through the documentation for this on npm and was confused by what the `STRING_CASE` and `STRING_CASE_ACRONYM` values for threshold were. I checked [the code](https://github.com/kentcdodds/match-sorter/blob/main/src/index.ts#L59) and they weren't in there. I searched the repo and they only show up in the README and in a very old PR. It looks like they used to be used a long time ago but at some point got removed.
