### PR TITLE
Prefer `Object.hasOwnProperty` for additional browser support

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
   "eslintConfig": {
     "extends": [
       "./node_modules/kcd-scripts/eslint.js"
-    ]
+    ],
+    "rules": {
+      "prefer-object-has-own": "off"
+    }
   },
   "eslintIgnore": [
     "node_modules",

--- a/src/index.ts
+++ b/src/index.ts
@@ -368,7 +368,7 @@ function getItemValues<ItemType>(
     value = key(item)
   } else if (item == null) {
     value = null
-  } else if (Object.hasOwn(item, key)) {
+  } else if (Object.hasOwnProperty.call(item, key)) {
     value = (item as IndexableByString)[key]
   } else if (key.includes('.')) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
@@ -412,7 +412,7 @@ function getNestedValues<ItemType>(
 
       if (nestedItem == null) continue
 
-      if (Object.hasOwn(nestedItem as object, nestedKey)) {
+      if (Object.hasOwnProperty.call(nestedItem, nestedKey)) {
         const nestedValue = (nestedItem as IndexableByString)[nestedKey]
         if (nestedValue != null) {
           nestedValues.push(nestedValue as IndexableByString | string)


### PR DESCRIPTION
Keeping support for older browsers by reverting the change to `Object.hasOwn` and disabling the eslint rule for the project.

Fixes: https://github.com/kentcdodds/match-sorter/issues/150

**What**: Revert back to using `Object.hasOwnProperty` instead of `Object.hasOwn`
**Why**: `Object.hasOwn` is still unsupported by some older legacy browsers that were supported before this change.
**How**: Reverted back the two changed lines and disabled the `prefer-object-has-own` in the eslint config (could also do this line-by-line, but this prevents it from accidentally being re-introduced in the project).

**Checklist**:
- [ ] Documentation (N/A)
- [ ] Tests (N/A)
- [x] Ready to be merged
