### PR TITLE
feat: add returnRankingInfo option to return ranking info along with results

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Feedback welcome!
   - [keys: `[string]`](#keys-string)
   - [threshold: `number`](#threshold-number)
   - [keepDiacritics: `boolean`](#keepdiacritics-boolean)
+  - [returnRankingInfo: `boolean`](#returnRankingInfo-boolean)
   - [baseSort: `function(itemA, itemB): -1 | 0 | 1`](#basesort-functionitema-itemb--1--0--1)
   - [sorter: `function(rankedItems): rankedItems`](#sorter-functionrankeditems-rankeditems)
 - [Recipes](#recipes)
@@ -319,6 +320,57 @@ matchSorter(thingsWithDiacritics, 'aa', {keepDiacritics: true})
 
 matchSorter(thingsWithDiacritics, 'à', {keepDiacritics: true})
 // ['à la carte', 'à la mode']
+```
+
+### returnRankingInfo: `boolean`
+
+_Default: `false`_
+
+By default, match-sorter will return matched and sorted items but not the
+ranking info.
+
+You can choose to have ranking info included by specifying
+`returnRankingInfo: true`
+
+```javascript
+const list = [
+  {country: 'Italy', counter: 3, value: 1},
+  {country: 'Italy', counter: 2, value: 2},
+  {country: 'Italy', counter: 1, value: 3},
+]
+matchSorter(list, '3', {keys: ['country', 'counter', 'value']})
+// [{country: 'Italy', counter: 3, value: 1}, {country: 'Italy', counter: 1, value: 3}]
+
+matchSorter(list, '3', {
+  keys: ['country', 'counter', 'value'],
+  returnRankingInfo: true,
+})
+// [
+//   {
+//     index: 0,
+//     item: {
+//       counter: 3,
+//       country: 'Italy',
+//       value: 1,
+//     },
+//     keyIndex: 1, // 'counter'
+//     keyThreshold: undefined,
+//     rank: 7,
+//     rankedValue: '3',
+//   },
+//   {
+//     index: 2,
+//     item: {
+//       counter: 1,
+//       country: 'Italy',
+//       value: 3,
+//     },
+//     keyIndex: 2, // 'value'
+//     keyThreshold: undefined,
+//     rank: 7,
+//     rankedValue: '3',
+//   },
+// ]
 ```
 
 ### baseSort: `function(itemA, itemB): -1 | 0 | 1`

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -507,6 +507,46 @@ const tests: Record<string, TestCase> = {
     ],
     output: ['applebutter', 'app', 'A apple', 'B apple', 'C apple', 'appl'],
   },
+  'returns ranking info when returnRankingInfo specified as true': {
+    input: [
+      [
+        {country: 'Italy', counter: 3, value: 1},
+        {country: 'Italy', counter: 2, value: 2},
+        {country: 'Italy', counter: 1, value: 3},
+      ],
+      '3',
+      {
+        keys: ['country', 'counter', 'value'],
+        returnRankingInfo: true,
+      },
+    ],
+    output: [
+      {
+        index: 0,
+        item: {
+          counter: 3,
+          country: 'Italy',
+          value: 1,
+        },
+        keyIndex: 1,
+        keyThreshold: undefined,
+        rank: 7,
+        rankedValue: '3',
+      },
+      {
+        index: 2,
+        item: {
+          counter: 1,
+          country: 'Italy',
+          value: 3,
+        },
+        keyIndex: 2,
+        keyThreshold: undefined,
+        rank: 7,
+        rankedValue: '3',
+      },
+    ],
+  },
 }
 
 for (const [

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ interface MatchSorterOptions<ItemType = unknown> {
   threshold?: Ranking
   baseSort?: BaseSorter<ItemType>
   keepDiacritics?: boolean
+  returnRankingInfo?: boolean
   sorter?: Sorter<ItemType>
 }
 type IndexableByString = Record<string, unknown>
@@ -82,8 +83,20 @@ const defaultBaseSortFn: BaseSorter<unknown> = (a, b) =>
 function matchSorter<ItemType = string>(
   items: ReadonlyArray<ItemType>,
   value: string,
+  options: MatchSorterOptions<ItemType> & {returnRankingInfo: true},
+): Array<RankedItem<ItemType>>
+
+function matchSorter<ItemType = string>(
+  items: ReadonlyArray<ItemType>,
+  value: string,
+  options?: MatchSorterOptions<ItemType>,
+): Array<ItemType>
+
+function matchSorter<ItemType = string>(
+  items: ReadonlyArray<ItemType>,
+  value: string,
   options: MatchSorterOptions<ItemType> = {},
-): Array<ItemType> {
+) {
   const {
     keys,
     threshold = rankings.MATCHES,
@@ -92,7 +105,10 @@ function matchSorter<ItemType = string>(
       matchedItems.sort((a, b) => sortRankedValues(a, b, baseSort)),
   } = options
   const matchedItems = items.reduce(reduceItemsToRanked, [])
-  return sorter(matchedItems).map(({item}) => item)
+  const sortedItems = sorter(matchedItems)
+  return options.returnRankingInfo
+    ? sortedItems
+    : sortedItems.map(({item}) => item)
 
   function reduceItemsToRanked(
     matches: Array<RankedItem<ItemType>>,


### PR DESCRIPTION
**What**: return ranking info along with results

**Why**: make it possible to highlight the value that was matched so the user better understands why a particular result is being displayed

**How**: add `returnRankingInfo` option

I initially thought about adding a `mapper` function, similar to `sorter`, but that was much harder to type and I didn't feel like it brought any useful benefits.

**Checklist**:

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
