### PR TITLE
feat: support finding data with typos

### DIFF
--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -54,6 +54,13 @@ const tests: Record<string, TestCase> = {
       'The Tail of Forty Cities', // match2
     ],
   },
+  'matches data that has minor typos': {
+    input: [
+      ['juptyer', 'juppyter', 'jopytar', 'jupytor', 'jepytur'],
+      'jupyter',
+    ],
+    output: ['juppyter', 'juptyer', 'jupytor'],
+  },
   'no match for single character inputs that are not equal': {
     input: [['abc'], 'd'],
     output: [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,7 +264,6 @@ function getClosenessRanking(
   stringToRank: string,
 ): Ranking {
   let matchingInOrderCharCount = 0
-  let charNumber = 0
   function findMatchingCharacter(
     matchChar: string,
     string: string,
@@ -279,23 +278,31 @@ function getClosenessRanking(
     }
     return -1
   }
+  let skipped = 0
   function getRanking(spread: number) {
     const spreadPercentage = 1 / spread
     const inOrderPercentage = matchingInOrderCharCount / stringToRank.length
-    const ranking = rankings.MATCHES + inOrderPercentage * spreadPercentage
+    const matchPercentage = (stringToRank.length - skipped) / stringToRank.length
+    const ranking = rankings.MATCHES + inOrderPercentage * spreadPercentage * matchPercentage
     return ranking as Ranking
   }
-  const firstIndex = findMatchingCharacter(stringToRank[0], testString, 0)
-  if (firstIndex < 0) {
-    return rankings.NO_MATCH
-  }
-  charNumber = firstIndex
-  for (let i = 1, I = stringToRank.length; i < I; i++) {
+  let firstIndex = 0
+  let charNumber = 0
+  let nextCharNumber = 0
+  for (let i = 0, I = stringToRank.length; i < I; i++) {
     const matchChar = stringToRank[i]
-    charNumber = findMatchingCharacter(matchChar, testString, charNumber)
-    const found = charNumber > -1
-    if (!found) {
+    nextCharNumber = findMatchingCharacter(matchChar, testString, charNumber)
+    const found = nextCharNumber > -1
+    if (found) {
+      charNumber = nextCharNumber
+      if (i === 0) {
+        firstIndex = charNumber
+      }
+    } else if (skipped > 0 || stringToRank.length <= 3) {
+      // if search term is short, require finding all characters
       return rankings.NO_MATCH
+    } else {
+      skipped += 1
     }
   }
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Increases tolerance for typos in data and/or query text

<!-- Why are these changes necessary? -->

**Why**: match sorter currently finds data with some typos, but others. E.g. "canceled" would find "cancelled", but not "cacneled".

<!-- How were these changes implemented? -->

**How**: `getClosenessRanking` calculator allows skipping one of the characters from the query. This allows finding data that contains the most common typos: swapped letters, missing letters and diverging spelling (localisation/localization). Matches that have missing letters have reduced ranking.

<!-- Have you done all of these things?  -->

**Checklist**:

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Since this change only affects searches where no good match (like full word, or exact start or word) gets found, I think there's no need to have add to options some flag to disable/enable this feature. If searching `ua` and finding `United States of America` is good enough right now, then my changes that improve tolerance for typos should be also acceptable.

But I can see that there could be some value in providing configuration for this new feature - and I am open to do it.