### PR TITLE
chore: replace @ts-expect-error with proper type assertions in test callbacks

### DIFF
--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -195,8 +195,13 @@ const tests: Record<string, TestCase> = {
     input: [
       [{name: {first: 'baz'}}, {name: {first: 'bat'}}, {name: {first: 'foo'}}],
       'ba',
-      // @ts-expect-error I don't know how to make this typed properly
-      {keys: [item => item.name.first]},
+      {
+        keys: [
+          ((item: {name: {first: string}}) => item.name.first) as (
+            item: unknown,
+          ) => string,
+        ],
+      },
     ],
     output: [{name: {first: 'bat'}}, {name: {first: 'baz'}}],
   },
@@ -618,8 +623,13 @@ const tests: Record<string, TestCase> = {
         {name: 'Jen_Smith'},
       ],
       'js',
-      // @ts-expect-error I don't know how to make this typed properly
-      {keys: [item => item.name.replace(/_/g, ' ')]},
+      {
+        keys: [
+          ((item: {name: string}) => item.name.replace(/_/g, ' ')) as (
+            item: unknown,
+          ) => string,
+        ],
+      },
     ],
     output: [{name: 'Jen_Smith'}, {name: 'Janice_Kurtis'}],
   },


### PR DESCRIPTION
**What**: Update test callbacks to use proper TypeScript typing

**Why**: Remove `@ts-expect-error` suppressions in favor of proper types

**How**: Replace with typed function callbacks and type assertions

**Checklist**:

- [x] Documentation - N/A (internal test changes only)
- [x] Tests - All 40 existing tests pass, TypeScript compiles cleanly
- [x] Ready to be merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved type safety in test cases by explicitly typing key functions and removing type suppression comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->