### PR TITLE
feat: expose rank info in results

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,26 @@ matchSorter(list, 'y') // ['yo', 'hey']
 matchSorter(list, 'z') // []
 ```
 
+If you need the ranking metadata that `match-sorter` computes internally, use
+`matchSorterWithRankInfo`:
+
+```javascript
+import {matchSorterWithRankInfo} from 'match-sorter'
+
+const rankedResults = matchSorterWithRankInfo(list, 'h')
+// [
+//   {
+//     item: 'hello',
+//     rankedValue: 'hello',
+//     rank: 5,
+//     keyIndex: -1,
+//     keyThreshold: undefined,
+//     index: 2,
+//   },
+//   // ...
+// ]
+```
+
 ## Advanced options
 
 ### keys: `[string]`
@@ -168,9 +188,9 @@ using dot-notation with the `*` wildcard instead of a numeric index.
 
 ```javascript
 const nestedObjList = [
-  {aliases: [{name: {first: 'Janice'}},{name: {first: 'Jen'}}]},
-  {aliases: [{name: {first: 'Fred'}},{name: {first: 'Frederic'}}]},
-  {aliases: [{name: {first: 'George'}},{name: {first: 'Georgie'}}]},
+  {aliases: [{name: {first: 'Janice'}}, {name: {first: 'Jen'}}]},
+  {aliases: [{name: {first: 'Fred'}}, {name: {first: 'Frederic'}}]},
+  {aliases: [{name: {first: 'George'}}, {name: {first: 'Georgie'}}]},
 ]
 matchSorter(nestedObjList, 'jen', {keys: ['aliases.*.name.first']})
 // [{aliases: [{name: {first: 'Janice'}},{name: {first: 'Jen'}}]}]
@@ -355,6 +375,7 @@ _You can customize the core sorting behavior by specifying a custom `sorter`
 function:_
 
 Disable sorting entirely:
+
 ```javascript
 const list = ['appl', 'C apple', 'B apple', 'A apple', 'app', 'applebutter']
 matchSorter(list, 'apple', {sorter: rankedItems => rankedItems})
@@ -362,6 +383,7 @@ matchSorter(list, 'apple', {sorter: rankedItems => rankedItems})
 ```
 
 Return the unsorted rankedItems, but in reverse order:
+
 ```javascript
 const list = ['appl', 'C apple', 'B apple', 'A apple', 'app', 'applebutter']
 matchSorter(list, 'apple', {sorter: rankedItems => [...rankedItems].reverse()})

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -1,4 +1,10 @@
-import {matchSorter, rankings, MatchSorterOptions} from '../'
+import {
+  matchSorter,
+  matchSorterWithRankInfo,
+  rankings,
+  MatchSorterOptions,
+  type RankedItem,
+} from '../'
 
 type TestCase = {
   input: [Array<unknown>, string, MatchSorterOptions?]
@@ -662,6 +668,69 @@ for (const [
     test(title, testFn)
   }
 }
+
+test('can return ranked items with ranking metadata attached', () => {
+  const rankedResults: Array<RankedItem<{tea: string; alias: string}>> =
+    matchSorterWithRankInfo(
+      [
+        {tea: 'Earl Grey', alias: 'A'},
+        {tea: 'Assam', alias: 'B'},
+        {tea: 'Black', alias: 'C'},
+      ],
+      'A',
+      {
+        keys: ['tea', {maxRanking: rankings.STARTS_WITH, key: 'alias'}],
+      },
+    )
+
+  expect(rankedResults).toEqual([
+    {
+      item: {tea: 'Assam', alias: 'B'},
+      rankedValue: 'Assam',
+      rank: rankings.STARTS_WITH,
+      keyIndex: 0,
+      keyThreshold: undefined,
+      index: 1,
+    },
+    {
+      item: {tea: 'Earl Grey', alias: 'A'},
+      rankedValue: 'A',
+      rank: rankings.STARTS_WITH,
+      keyIndex: 1,
+      keyThreshold: undefined,
+      index: 0,
+    },
+    {
+      item: {tea: 'Black', alias: 'C'},
+      rankedValue: 'Black',
+      rank: rankings.CONTAINS,
+      keyIndex: 0,
+      keyThreshold: undefined,
+      index: 2,
+    },
+  ])
+})
+
+test('can return ranked items without passing options', () => {
+  expect(matchSorterWithRankInfo(['hello', 'hey', 'sup'], 'h')).toEqual([
+    {
+      item: 'hello',
+      rankedValue: 'hello',
+      rank: rankings.STARTS_WITH,
+      keyIndex: -1,
+      keyThreshold: undefined,
+      index: 0,
+    },
+    {
+      item: 'hey',
+      rankedValue: 'hey',
+      rank: rankings.STARTS_WITH,
+      keyIndex: -1,
+      keyThreshold: undefined,
+      index: 1,
+    },
+  ])
+})
 
 /*
 eslint

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,29 @@ function matchSorter<ItemType = string>(
   value: string,
   options: MatchSorterOptions<ItemType> = {},
 ): Array<ItemType> {
+  return getRankedItems(items, value, options).map(({item}) => item)
+}
+
+/**
+ * Takes an array of items and a value and returns ranked items with metadata attached
+ * @param {Array} items - the items to sort
+ * @param {String} value - the value to use for ranking
+ * @param {Object} options - Some options to configure the sorter
+ * @return {Array} - the new ranked array
+ */
+function matchSorterWithRankInfo<ItemType = string>(
+  items: ReadonlyArray<ItemType>,
+  value: string,
+  options: MatchSorterOptions<ItemType> = {},
+): Array<RankedItem<ItemType>> {
+  return getRankedItems(items, value, options)
+}
+
+function getRankedItems<ItemType = string>(
+  items: ReadonlyArray<ItemType>,
+  value: string,
+  options: MatchSorterOptions<ItemType>,
+): Array<RankedItem<ItemType>> {
   const {
     keys,
     threshold = rankings.MATCHES,
@@ -92,7 +115,7 @@ function matchSorter<ItemType = string>(
       matchedItems.sort((a, b) => sortRankedValues(a, b, baseSort)),
   } = options
   const matchedItems = items.reduce(reduceItemsToRanked, [])
-  return sorter(matchedItems).map(({item}) => item)
+  return sorter(matchedItems)
 
   function reduceItemsToRanked(
     matches: Array<RankedItem<ItemType>>,
@@ -109,6 +132,7 @@ function matchSorter<ItemType = string>(
 }
 
 matchSorter.rankings = rankings
+matchSorterWithRankInfo.rankings = rankings
 
 /**
  * Gets the highest ranking for value for the given item based on its values for the given keys
@@ -520,7 +544,13 @@ function getKeyAttributes<ItemType>(key: KeyOption<ItemType>): KeyAttributes {
   return {...defaultKeyAttributes, ...key}
 }
 
-export {matchSorter, rankings, defaultBaseSortFn, getItemValues}
+export {
+  matchSorter,
+  matchSorterWithRankInfo,
+  rankings,
+  defaultBaseSortFn,
+  getItemValues,
+}
 
 export type {
   MatchSorterOptions,
@@ -528,6 +558,7 @@ export type {
   KeyOption,
   KeyAttributes,
   RankingInfo,
+  RankedItem,
   ValueGetterKey,
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Allow callers to opt into match metadata so they can use ranking details without reimplementing the sorter.

<!-- Why are these changes necessary? -->

**Why**:

For cases when you want to use matchSort but need to save/extract information about how each item was ranked after matchSort runs.

<!-- How were these changes implemented? -->

**How**:

Added a new option called `returnRankInfo` and an overload for matchSorter. When `returnRankInfo` is true, the return type is `{item: T, ...rankInfo}[]` but when false it is still just `T[]`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new function that returns matched items with ranking metadata (item, rankedValue, rank, keyIndex, keyThreshold, index).

* **Documentation**
  * README updated with usage examples showing the new ranked-item output and improved code formatting in examples.

* **Tests**
  * Added tests verifying the ranked-item output structure, ordering, and behavior both with and without options.

* **Refactor**
  * Core matching now centralizes ranking so existing match results continue to work while enabling the new ranked-output function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->